### PR TITLE
openshift/from-source now works with latest linch-pin

### DIFF
--- a/config/topologies/duffy-3node-cluster.yml
+++ b/config/topologies/duffy-3node-cluster.yml
@@ -2,7 +2,7 @@
 topology_name: "duffy_3node_cluster" # topology name
 resource_groups:
   -
-    resource_group_name: "duffy_3node_cluster"
+    resource_group_name: "duffy-3node-cluster"
     res_group_type: "duffy"
     res_defs:
       -

--- a/config/topologies/duffy_3node_cluster.yml
+++ b/config/topologies/duffy_3node_cluster.yml
@@ -2,7 +2,7 @@
 topology_name: "duffy_3node_cluster" # topology name
 resource_groups:
   -
-    resource_group_name: "duffy-3node-cluster"
+    resource_group_name: "duffy_3node_group"
     res_group_type: "duffy"
     res_defs:
       -

--- a/jjb/openshift/from-source/ofs-macros.yaml
+++ b/jjb/openshift/from-source/ofs-macros.yaml
@@ -5,7 +5,7 @@
     site: duffy
     jslave_name: paas-sig-ci-slave01
     jslave_username: root
-    lp_sha1: 77e5613227df670efc5e877134fce67432e5e97d
+    lpsha1: 77e5613227df670efc5e877134fce67432e5e97d
     provision-pb: $WORKSPACE/linch-pin/provision/site.yml
     inventory-layout-file: openshift-3node-inventory.yml
     prep-pb: paas-ci/playbooks/openshift/setup.yml
@@ -88,28 +88,3 @@
     jobs:
       - openshift-provision-prep-test-teardown
 
-#    run-install: |
-#      #!/bin/bash
-#      set -xeuo pipefail
-#
-#      # Run openshift-ansible
-#      chmod 600 $WORKSPACE/{ssh_keyfile}
-#      ansible-playbook \
-#        $WORKSPACE/{oa-playbook}
-#    run-e2e-tests: |
-#      #!/bin/bash
-#      set -xeuo pipefail
-#
-#      # Run e2e tests
-#      chmod 600 $WORKSPACE/{ssh_keyfile}
-#      ansible-playbook \
-#        $WORKSPACE/{run-e2e-tests-pb}
-#    teardown-cluster: |
-#      #!/bin/bash
-#      set -xeuo pipefail
-#
-#      # Run upgrade
-#      ansible-playbook \
-#        -i $WORKSPACE/ci-factory/utils/central_ci_dynamic_hosts.py \
-#        --private-key=$WORKSPACE/{ssh_keyfile} \
-#        $WORKSPACE/{upgrade-ose-pb}

--- a/jjb/openshift/from-source/ofs-macros.yaml
+++ b/jjb/openshift/from-source/ofs-macros.yaml
@@ -5,6 +5,7 @@
     site: duffy
     jslave_name: paas-sig-ci-slave01
     jslave_username: root
+    lp_sha1: 77e5613227df670efc5e877134fce67432e5e97d
     provision-pb: $WORKSPACE/linch-pin/provision/site.yml
     inventory-layout-file: openshift-3node-inventory.yml
     prep-pb: paas-ci/playbooks/openshift/setup.yml
@@ -29,12 +30,13 @@
       #!/bin/bash
       set -xeuo pipefail
 
+      mkdir -p $WORKSPACE/inventory
+
       # provision cluster
       ansible-playbook {provision-pb} -u root -v \
       -e "topology=$WORKSPACE/paas-ci/config/topologies/${{TOPOLOGY}}.yml" \
       -e "inventory_layout_file=$WORKSPACE/paas-ci/config/inv_layouts/{inventory-layout-file}" \
-      -e "inventory_output_file=$WORKSPACE/inventory/${{TOPOLOGY}}.inventory" \
-      -e "schema=$WORKSPACE/linch-pin/ex_schemas/schema_v2.json state=present"
+      -e "inventory_outputs_path=$WORKSPACE/inventory" -e "state=present"
     prep-cluster: |
       #!/bin/bash
       set -xeuo pipefail

--- a/jjb/openshift/from-source/ofs-macros.yaml
+++ b/jjb/openshift/from-source/ofs-macros.yaml
@@ -48,7 +48,7 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v -i $WORKSPACE/inventory/ \
+      ansible-playbook -u root -v \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{ofs-pb}
     oa-from-source: |

--- a/jjb/openshift/from-source/origin-from-source.yaml
+++ b/jjb/openshift/from-source/origin-from-source.yaml
@@ -19,7 +19,7 @@
           type: user-defined
           name: TOPOLOGY
           values:
-            - duffy-3node-cluster
+            - duffy_3node_cluster
       - axis:
           type: python
           values:
@@ -55,7 +55,7 @@
           {run-e2e-tests}
     publishers:
         - archive:
-            artifacts: "**/*.output, **/*.inventory"
+            artifacts: "**/*.output, **/${{TOPOLOGY}}.inventory"
             allow-empty: 'false'
         - conditional-publisher:
             - condition-kind: current-status

--- a/jjb/openshift/from-source/origin-from-source.yaml
+++ b/jjb/openshift/from-source/origin-from-source.yaml
@@ -1,66 +1,6 @@
-#######################################
-## MULTI-JOB TO WRAP AROUND ALL JOBS ##
-#######################################
-
-#- job-template:
-#    name: '{ocname}-0-multijob'
-#    defaults: openshift-defaults
-#    concurrent: false
-#    node: master
-#    project-type: multijob
-#    scm:
-#        - paas-sig-ci-scm
-#    triggers:
-#        - timed: "H */12 * * *"
-#    builders:
-#      - multijob:
-#          name: ProvisionCluster
-#          condition: SUCCESSFUL
-#          projects:
-#            - name: '{ocname}-1-provision-cluster'
-#              kill-phase-on: FAILURE
-#              abort-all-job: true
-#              current-parameters: true
-#      - multijob:
-#          name: PrepCluster
-#          condition: SUCCESSFUL
-#          projects:
-#            - name: '{ocname}-2-prep-cluster'
-#              kill-phase-on: FAILURE
-#              abort-all-job: true
-#              current-parameters: true
-#      - multijob:
-#          name: TeardownCluster
-#          condition: SUCCESSFUL
-#          projects:
-#            - name: '{ocname}-6-teardown-cluster'
-#              kill-phase-on: FAILURE
-#              abort-all-job: true
-#              current-parameters: true
-#      - multijob:
-#          name: OpenshiftAnsibleRpms
-#          condition: SUCCESSFUL
-#          projects:
-#            - name: '{ocname}-4-openshift-ansible-rpms'
-#              kill-phase-on: FAILURE
-#              abort-all-job: true
-#              current-parameters: true
-#      - multijob:
-#          name: DeployAOSI
-#          condition: SUCCESSFUL
-#          projects:
-#            - name: '{ocname}-5-deploy-aosi'
-#              kill-phase-on: FAILURE
-#              abort-all-job: true
-#              current-parameters: true
-#      - multijob:
-#          name: Provision-Deploy-e2etests
-#          condition: SUCCESSFUL
-#          projects:
-#            - name: '{ocname}-6-test-matrix'
-#              kill-phase-on: FAILURE
-#              abort-all-job: true
-#              current-parameters: true
+############################################
+## MATRIX JOB TO BUILD ORIGIN FROM SOURCE ##
+############################################
 
 #    parameters:
 #      - label:

--- a/jjb/openshift/from-source/origin-from-source.yaml
+++ b/jjb/openshift/from-source/origin-from-source.yaml
@@ -54,15 +54,16 @@
       - shell: |
           {run-e2e-tests}
     publishers:
-        - archive:
-            artifacts: "**/*.output, **/${{TOPOLOGY}}.inventory"
-            allow-empty: 'false'
-        - conditional-publisher:
-            - condition-kind: current-status
-              condition-worst: ABORTED
-              condition-best: UNSTABLE
-              action:
-                - teardown-cluster
+      - archive:
+          artifacts: "**/*.output, **/${{TOPOLOGY}}.inventory"
+          allow-empty: 'false'
+      - openshift-email
+      - conditional-publisher:
+          - condition-kind: current-status
+            condition-worst: ABORTED
+            condition-best: UNSTABLE
+            action:
+              - teardown-cluster
 
 - publisher:
     name: 'teardown-cluster'

--- a/jjb/openshift/openshift-defaults.yml
+++ b/jjb/openshift/openshift-defaults.yml
@@ -2,6 +2,7 @@
     name: openshift-defaults
     description: |
         Maintainer: <a href="mailto:herlo@redhat.com>Clint Savage</a>
+        Secondary Maintainer: <a href="mailto:alivigni@redhat.com>Ari LiVigni</a>
         Code Location: http://github.com/CentOS-PaaS-SIG/paas-sig-ci
         IRC: #centos-devel on freenode<br/><br/>
         Mailing List: <a href="mailto:centos-devel@centos.org">CentOS Devel</a>
@@ -21,7 +22,7 @@
             artifact-num-to-keep: 15
         - inject:
             properties-content: |
-              lp_sha1=${lpsha1}
+              lp_sha1={lpsha1}
 
 - scm:
     name: paas-sig-ci-scm
@@ -33,13 +34,13 @@
             basedir: paas-ci
             skip-tag: true
         - git:
-            url: 'git://github.com/herlo/duffy-ansible-module.git'
+            url: 'git://github.com/CentOS-PaaS-SIG/duffy-ansible-module.git'
             branches:
                 - origin/master
             basedir: duffy-ansible-module
             skip-tag: true
         - git:
-            url: 'git://github.com/herlo/linch-pin.git'
+            url: 'git://github.com/CentOS-PaaS-SIG/linch-pin.git'
             branches:
                 - ${lp_sha1}
             basedir: linch-pin

--- a/jjb/openshift/openshift-defaults.yml
+++ b/jjb/openshift/openshift-defaults.yml
@@ -28,7 +28,7 @@
         - git:
             url: 'git://github.com/herlo/linch-pin.git'
             branches:
-                - origin/master
+                - ${lp-sha1}
             basedir: linch-pin
             skip-tag: true
 

--- a/jjb/openshift/openshift-defaults.yml
+++ b/jjb/openshift/openshift-defaults.yml
@@ -1,5 +1,11 @@
 - defaults:
     name: openshift-defaults
+    description: |
+        Maintainer: <a href="mailto:herlo@redhat.com>Clint Savage</a>
+        Code Location: http://github.com/CentOS-PaaS-SIG/paas-sig-ci
+        IRC: #centos-devel on freenode<br/><br/>
+        Mailing List: <a href="mailto:centos-devel@centos.org">CentOS Devel</a>
+        Managed by Jenkins Job Builder. Do not edit via the web interface.
     node: openshift-ansible-slave
     wrappers:
         - ansicolor
@@ -9,6 +15,13 @@
             properties-content: |
                 ANSIBLE_SSH_CONTROL_PATH=%(directory)s/%%h-%%r
                 ANSIBLE_HOST_KEY_CHECKING=False
+    properties:
+        - build-discarder:
+            num-to-keep: 50
+            artifact-num-to-keep: 15
+        - inject:
+            properties-content: |
+              lp_sha1=${lpsha1}
 
 - scm:
     name: paas-sig-ci-scm
@@ -28,9 +41,37 @@
         - git:
             url: 'git://github.com/herlo/linch-pin.git'
             branches:
-                - ${lp-sha1}
+                - ${lp_sha1}
             basedir: linch-pin
             skip-tag: true
+
+- publisher:
+    name: openshift-email
+    publishers:
+      - email-ext:
+          recipients: herlo@redhat.com,tdawson@redhat.com
+          reply-to: $DEFAULT_REPLYTO
+          content-type: default
+          subject: $DEFAULT_SUBJECT CentOS-PaaS-SIG
+          body: $DEFAULT_CONTENT
+          attach-build-log: false
+          always: false
+          unstable: false
+          first-failure: true
+          not-built: false
+          aborted: true
+          regression: true
+          failure: false
+          improvement: false
+          still-failing: false
+          success: false
+          fixed: true
+          still-unstable: false
+          pre-build: false
+          matrix-trigger: only-configurations
+          send-to:
+            - requester
+            - recipients
 
 ## Teardown Resources
 - publisher:

--- a/playbooks/openshift/group_vars/all/global.yml
+++ b/playbooks/openshift/group_vars/all/global.yml
@@ -1,10 +1,5 @@
 ---
-# Version to setup of origin
-origin_version: 1.2
+# Version of openshift-ansible
+oa_version: 3.2
 
-# By default, the openshift yum repository is enabled.
-# To disable it, uncomment this line or pass 'repo_from_source=True'
-# via --extra-vars
-
-#repo_from_source: True
 

--- a/playbooks/openshift/group_vars/all/global.yml
+++ b/playbooks/openshift/group_vars/all/global.yml
@@ -1,5 +1,8 @@
 ---
+# Version to setup of origin
+origin_version: 1.3
+
 # Version of openshift-ansible
-oa_version: 3.2
+oa_version: 3.3
 
 

--- a/playbooks/openshift/roles/common/tasks/install_required_pkgs.yml
+++ b/playbooks/openshift/roles/common/tasks/install_required_pkgs.yml
@@ -14,9 +14,8 @@
 # - docker
 # - yum-utils
 #
-# yum update comes in 2.0
 - name: update all packages
-  command: yum update -y
+  yum: name=* state=latest
 
 - name: Install packages on masters and nodes
   yum: name={{ item }} state=present

--- a/playbooks/openshift/roles/ofs/tasks/clone_from_github.yml
+++ b/playbooks/openshift/roles/ofs/tasks/clone_from_github.yml
@@ -5,6 +5,10 @@
   register: dot_git_path
 
 - name: git clone origin
-  git: repo=https://github.com/openshift/origin
-      dest={{ openshift_repo_path }} clone=yes update=yes
+  git:
+    repo: https://github.com/openshift/origin
+    dest: "{{ openshift_repo_path }}"
+    clone: yes
+    update: yes
+    accept_hostkey: yes
   when: dot_git_path.stat.isdir is undefined or dot_git_path.stat.isdir == False


### PR DESCRIPTION
openshift/from-source now works with linch-pin, includes fixes to playbooks, jjb, and topology.
Also, it now emails upon failure and fixed scenarios (thanks @arilivigni)