### PR TITLE
Updated e2e test playbooks to facilitate containerrun

### DIFF
--- a/playbooks/openshift/roles/e2e/tasks/execute_e2e_tests.yml
+++ b/playbooks/openshift/roles/e2e/tasks/execute_e2e_tests.yml
@@ -4,34 +4,34 @@
   run_once: true
   register: e2e_execution
   ignore_errors: yes
-  when: containerrun == false
+  when: containerrun == "false"
 
 - name: fetch remote kubeconfig
   fetch:
     src: /etc/origin/master/admin.kubeconfig
     dest: /tmp/admin.kubeconfig
     flat: yes
-  when: containerrun == true
+  when: containerrun == "true"
   
 - name: Execute extended.tests binary with set of tests
   shell: KUBECONFIG=/tmp/admin.kubeconfig {{ extended_test_binary }} --ginkgo.v={{ ginkgo_v }} --ginkgo.skip="{{ ginkgo_skip }}" --ginkgo.focus="{{ ginkgo_focus }}" 1>/tmp/e2e.log 2>&1
   run_once: true
   register: e2e_execution
   delegate_to: localhost
-  when: containerrun == true
+  when: containerrun == "true"
 
 - name: Print out results from running e2e tests
   shell: cat /tmp/e2e.log
   run_once: true
   register: e2e_log_output
   delegate_to: localhost
-  when: containerrun == true
+  when: containerrun == "true"
 
 - name: Print out results from running e2e tests
   shell: cat e2e.log
   run_once: true
   register: e2e_log_output
-  when: containerrun == false
+  when: containerrun == "false"
 
 - name: Grab e2e.log file from test run
   fetch:
@@ -41,4 +41,4 @@
     flat: yes
   run_once: true
   failed_when: "e2e_execution.rc != 0"
-  when: containerrun == false
+  when: containerrun == "false"

--- a/playbooks/openshift/roles/e2e/tasks/execute_e2e_tests.yml
+++ b/playbooks/openshift/roles/e2e/tasks/execute_e2e_tests.yml
@@ -1,22 +1,37 @@
 ---
+- name: Execute extended.tests binary with set of tests
+  shell: KUBECONFIG=/etc/origin/master/admin.kubeconfig {{ extended_test_binary }} --ginkgo.v={{ ginkgo_v }} --ginkgo.skip="{{ ginkgo_skip }}" --ginkgo.focus="{{ ginkgo_focus }}" 1>e2e.log 2>&1
+  run_once: true
+  register: e2e_execution
+  ignore_errors: yes
+  when: containerrun == false
+
 - name: fetch remote kubeconfig
   fetch:
     src: /etc/origin/master/admin.kubeconfig
     dest: /tmp/admin.kubeconfig
     flat: yes
-
+  when: containerrun == true
+  
 - name: Execute extended.tests binary with set of tests
   shell: KUBECONFIG=/tmp/admin.kubeconfig {{ extended_test_binary }} --ginkgo.v={{ ginkgo_v }} --ginkgo.skip="{{ ginkgo_skip }}" --ginkgo.focus="{{ ginkgo_focus }}" 1>/tmp/e2e.log 2>&1
   run_once: true
   register: e2e_execution
   delegate_to: localhost
+  when: containerrun == true
 
 - name: Print out results from running e2e tests
   shell: cat /tmp/e2e.log
   run_once: true
   register: e2e_log_output
   delegate_to: localhost
+  when: containerrun == true
 
+- name: Print out results from running e2e tests
+  shell: cat e2e.log
+  run_once: true
+  register: e2e_log_output
+  when: containerrun == false
 
 - name: Grab e2e.log file from test run
   fetch:
@@ -26,4 +41,4 @@
     flat: yes
   run_once: true
   failed_when: "e2e_execution.rc != 0"
-  ignore_errors: yes
+  when: containerrun == false

--- a/playbooks/openshift/roles/e2e/tasks/execute_e2e_tests.yml
+++ b/playbooks/openshift/roles/e2e/tasks/execute_e2e_tests.yml
@@ -1,14 +1,22 @@
 ---
+- name: fetch remote kubeconfig
+  fetch:
+    src: /etc/origin/master/admin.kubeconfig
+    dest: /tmp/admin.kubeconfig
+    flat: yes
+
 - name: Execute extended.tests binary with set of tests
-  shell: KUBECONFIG=/etc/origin/master/admin.kubeconfig {{ extended_test_binary }} --ginkgo.v={{ ginkgo_v }} --ginkgo.skip="{{ ginkgo_skip }}" --ginkgo.focus="{{ ginkgo_focus }}" 1>e2e.log 2>&1
+  shell: KUBECONFIG=/tmp/admin.kubeconfig {{ extended_test_binary }} --ginkgo.v={{ ginkgo_v }} --ginkgo.skip="{{ ginkgo_skip }}" --ginkgo.focus="{{ ginkgo_focus }}" 1>/tmp/e2e.log 2>&1
   run_once: true
   register: e2e_execution
-  ignore_errors: yes
+  delegate_to: localhost
 
 - name: Print out results from running e2e tests
-  shell: cat e2e.log
+  shell: cat /tmp/e2e.log
   run_once: true
   register: e2e_log_output
+  delegate_to: localhost
+
 
 - name: Grab e2e.log file from test run
   fetch:
@@ -18,3 +26,4 @@
     flat: yes
   run_once: true
   failed_when: "e2e_execution.rc != 0"
+  ignore_errors: yes

--- a/playbooks/openshift/roles/e2e/tasks/get_e2e_binary.yml
+++ b/playbooks/openshift/roles/e2e/tasks/get_e2e_binary.yml
@@ -1,3 +1,12 @@
 - name: Install atomic-openshift-tests
-  dnf: name=origin-tests state=present
+  yum:
+    name: origin-tests
+    state: present
+  when: containerrun == false
+
+- name: Install atomic-openshift-tests
+  dnf:
+    name: origin-tests
+    state: present
   delegate_to: localhost
+  when: containerrun == true

--- a/playbooks/openshift/roles/e2e/tasks/get_e2e_binary.yml
+++ b/playbooks/openshift/roles/e2e/tasks/get_e2e_binary.yml
@@ -2,11 +2,11 @@
   yum:
     name: origin-tests
     state: present
-  when: containerrun == false
+  when: containerrun == "false"
 
 - name: Install atomic-openshift-tests
   dnf:
     name: origin-tests
     state: present
   delegate_to: localhost
-  when: containerrun == true
+  when: containerrun == "true"

--- a/playbooks/openshift/roles/e2e/tasks/get_e2e_binary.yml
+++ b/playbooks/openshift/roles/e2e/tasks/get_e2e_binary.yml
@@ -1,2 +1,3 @@
 - name: Install atomic-openshift-tests
-  yum: name=origin-tests state=present
+  dnf: name=origin-tests state=present
+  delegate_to: localhost

--- a/playbooks/openshift/roles/e2e/tasks/main.yml
+++ b/playbooks/openshift/roles/e2e/tasks/main.yml
@@ -1,3 +1,5 @@
 ---
+- set_fact:
+    containerrun: "{{ containerrun | default(false) }}"
 - include: get_e2e_binary.yml
 - include: execute_e2e_tests.yml


### PR DESCRIPTION
Summary: 
In order to make the e2e tests run inside a container environment , containerrun conditional is introduced ( which defaults to false in normal run ) 
However , when running in a container env 
the command looks as follows: 
```
docker run -v inventory_path_on_host:inventory_path_on_container  -v ssh_key_path_on_host:ssh_key_path_on_container -e ANSIBLE_HOST_KEY_CHECKING=False container_name  ansible-playbook -vvvvv -i inventory_path_on_container playbooks/openshift/run_e2e_tests.yml -e'containerrun=true'" 
```
note:
The changes are made in such a way that , they would not effect the existing run as containerrun variable defaults to false.