### PR TITLE
Update for master bleeding_edge for origin and openshift-ansible

### DIFF
--- a/jjb/paas/paas-macros.yml
+++ b/jjb/paas/paas-macros.yml
@@ -32,7 +32,7 @@
       mkdir -p $WORKSPACE/inventory
 
       # provision cluster
-      ansible-playbook {provision-pb} -u root -v \
+      ansible-playbook {provision-pb} -u root -vv \
       -e "topology=$WORKSPACE/paas-ci/config/topologies/${{TOPOLOGY}}.yml" \
       -e "inventory_layout_file=$WORKSPACE/paas-ci/config/inv_layouts/{inventory-layout-file}" \
       -e "inventory_outputs_path=$WORKSPACE/inventory" -e "state=present"
@@ -41,7 +41,7 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{prep-pb} -e "repo_from_source=true"
     bfs-origin: |
@@ -49,7 +49,7 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{bfs-pb} \
       -e "repo_from_source=true" \
@@ -61,20 +61,21 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{bfs-pb} \
       -e "repo_from_source=true" \
       -e "project=openshift-ansible" \
       -e "version=${{OA_VERSION}}" \
       -e "origin_version=${{ORIGIN_VERSION}}" \
-      -e "arch=noarch"
+      -e "arch=noarch" \
+      -e "bleeding_edge=${{BE}}"
     deploy-aosi: |
       #!/bin/bash
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{deploy-aosi-pb} \
       -e "version=${{ORIGIN_VERSION}}"
@@ -83,7 +84,7 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{run-e2e-pb}
     cbs-origin: |
@@ -91,7 +92,7 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{cbs-pb} -e "project=origin" \
       -e "scratch=${{SCRATCH}}"
@@ -100,7 +101,7 @@
       set -xeuo pipefail
 
       # see what we have in terms of inventory
-      ansible-playbook -u root -v \
+      ansible-playbook -u root -vv \
       -i $WORKSPACE/inventory/${{TOPOLOGY}}.inventory \
       $WORKSPACE/{cbs-pb} -e "project=openshift-ansible" \
       -e "scratch=${{SCRATCH}}"
@@ -109,7 +110,7 @@
       set -xeuo pipefail
 
       # teardown cluster
-      ansible-playbook {provision-pb} -u root -v \
+      ansible-playbook {provision-pb} -u root -vv \
       -e "topology=$WORKSPACE/paas-ci/config/topologies/${{TOPOLOGY}}.yml" \
       -e "schema=$WORKSPACE/linch-pin/ex_schemas/schema_v2.json state=absent"
     jobs:

--- a/playbooks/openshift/roles/bfs/tasks/build_openshift-ansible_repo.yml
+++ b/playbooks/openshift/roles/bfs/tasks/build_openshift-ansible_repo.yml
@@ -10,6 +10,7 @@
     - { prop: 'project', value: "{{ project }}" }
     - { prop: 'version', value: "{{ version }}" }
     - { prop: 'latest_tag', value: "{{ LATEST_TAG.stdout }}" }
+    - { prop: 'bleeding_edge', value: "{{ bleeding_edge }}" }
 
 - name: check if changes have been applied
   shell: "git log -n1 | grep 'Update variants for origin - {{ LATEST_TAG.stdout }}'"
@@ -22,7 +23,7 @@
   shell: "git checkout {{ project }}-{{ version }}.{{ LATEST_TAG.stdout }}"
   args:
     chdir: "{{ openshift_repo_path }}"
-  when: git_log.stdout == ""
+  when: (git_log.stdout == "" and bleeding_edge|bool == false)
 
 - name: update version of origin
   lineinfile:

--- a/playbooks/openshift/roles/bfs/tasks/build_origin_repo.yml
+++ b/playbooks/openshift/roles/bfs/tasks/build_origin_repo.yml
@@ -3,6 +3,8 @@
   with_items:
     - { prop: 'project', value: "{{ project }}" }
     - { prop: 'version', value: "{{ version }}" }
+    - { prop: 'bleeding_edge', value: "{{ bleeding_edge }}" }
+    - { prop: 'force_build', value: "{{ force_build }}" }
 
 - name: Start and enable docker service
   service:

--- a/playbooks/openshift/roles/setup/tasks/setup_docker.yml
+++ b/playbooks/openshift/roles/setup/tasks/setup_docker.yml
@@ -1,7 +1,7 @@
 - name: Change Docker configuration
   lineinfile: dest=/etc/sysconfig/docker
               regexp=^OPTIONS=.*
-              line="OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled'"
+              line="OPTIONS='--insecure-registry=172.30.0.0/16 --selinux-enabled --log-driver=journald --signature-verification=false --storage-opt dm.basesize=20G'"
               state=present
 
 - name: Extend timeout for docker start


### PR DESCRIPTION
- Issue with running origin build on master space required above 10GB
  for container.  increased loopback to base size of 20G
- Setup bleeding_edge for openshift ansible in playbook roles and jobs
- Adding next level verbosity to playbooks and more debug output in
  roles