### PR TITLE
Trim version off release

### DIFF
--- a/playbooks/openshift/roles/bfs/tasks/build_openshift_srpm.yml
+++ b/playbooks/openshift/roles/bfs/tasks/build_openshift_srpm.yml
@@ -52,7 +52,7 @@
   lineinfile:
     dest: "{{ openshift_repo_path }}/origin.spec"
     regexp: "^Release:.*$"
-    line: "Release:        0.{{ origin_version | regex_replace('-', '.') | regex_replace('v') }}%{package_dist}"
+    line: "Release:        0.{{ origin_version.split('-')[1] }}%{package_dist}"
     backrefs: yes
     state: present
 


### PR DESCRIPTION
The release currently has both the version and release, which is making the rpm NVR very redundant.
This should trim
  origin-3.8.0-0.3.8.0.alpha.1.el7.git.0.bbb7e37
down to
  origin-3.8.0-0.alpha.1.el7.git.0.bbb7e37