### PR TITLE
No longer need to delete origin git tag as it was done back when the …

### DIFF
--- a/playbooks/openshift/roles/bfs/tasks/build_openshift_srpm.yml
+++ b/playbooks/openshift/roles/bfs/tasks/build_openshift_srpm.yml
@@ -29,15 +29,6 @@
     - git_log.stdout == ""
     - not ( bleeding_edge | bool )
 
-- name: delete tag origin version - {{ origin_version }}
-  shell: git tag -d {{ origin_version }}
-  args:
-    chdir: "{{ openshift_repo_path }}"
-  when:
-    # TODO come back to this
-    - git_log.stdout == ""
-    - not ( bleeding_edge | bool )
-
 - name: patch tito's common.py since origin 3.7 is broken
   copy:
     src: "{{ role_path }}/files/common.py"


### PR DESCRIPTION
…--keep-version of tito wasn't working

@arilivigni pls help review, thx