### PR TITLE
Use our own ansible.cfg rather than the default CI slave.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
-env.ANSIBLE_SSH_CONTROL_PATH = "%(directory)s/%%h-%%r"
-env.ANSIBLE_HOST_KEY_CHECKING = false
-env.ANSIBLE_FORCE_COLOR = true
+env.PYTHONUNBUFFERED = 1
+env.ANSIBLE_CONFIG = '${WORKSPACE}/paas-ci/ansible.cfg'
 env.PAAS_SLAVE = "paas-sig-ci-slave01"
 env.BFS_PB = 'paas-ci/playbooks/openshift/bfs.yml'
 env.CBS_PB = 'paas-ci/playbooks/openshift/cbs.yml'
@@ -151,16 +150,16 @@ def duffyNode (String stage, String action) {
     sh '''
         #!/bin/bash
         set -xeuo pipefail
-    
+
         if [ "${ACTION}" == "get" ]; then
             cico node get
             cico inventory -c hostname -c comment -f csv --quote none 2>/dev/null | tail -1 | awk -F',' '{print $1}' > ${WORKSPACE}/duffy_host.inventory
             cico inventory -c hostname -c comment -f csv --quote none 2>/dev/null | tail -1 | awk -F',' '{print $2}' > ${WORKSPACE}/duffy_ssid.inventory
             DUFFY_HOST=$( cat ${WORKSPACE}/duffy_host.inventory )
-            sed -i "s/${DUFFY_HOST}//g" ~/.ssh/known_hosts    
+            sed -i "s/${DUFFY_HOST}//g" ~/.ssh/known_hosts
         else
             DUFFY_SSID=$( cat ${WORKSPACE}/duffy_ssid.inventory )
-            cico node done ${DUFFY_SSID} 
+            cico node done ${DUFFY_SSID}
         fi
     '''
 }
@@ -196,7 +195,7 @@ def bfs (String stage, String project) {
     sh '''
         #!/bin/bash
         set -xeuo pipefail
-    
+
         # see what we have in terms of inventory
         ${BFS_COMMAND}
     '''

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,28 @@
+[defaults]
+# Set the log_path
+#log_path = /tmp/ansible.log
+
+# Additional default options for OpenShift Ansible
+forks = 5
+host_key_checking = False
+retry_files_enabled = False
+nocows = True
+force_color = True
+remote_user = root
+#roles_path = roles/
+gathering = smart
+callback_whitelist = profile_tasks
+# work around privilege escalation timeouts in ansible:
+timeout = 30
+
+# Uncomment to use the provided example inventory
+#inventory = inventory/hosts.example
+
+# Additional ssh options for OpenShift Ansible
+[ssh_connection]
+pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s
+timeout = 10
+# shorten the ControlPath which is often too long; when it is,
+# ssh connection reuse silently fails, making everything slower.
+control_path = %(directory)s/%%h-%%r

--- a/playbooks/openshift/roles/bfs/tasks/main.yml
+++ b/playbooks/openshift/roles/bfs/tasks/main.yml
@@ -10,4 +10,3 @@
 
 - include: build_openshift-ansible_srpm.yml
   when: project == 'openshift-ansible'
-


### PR DESCRIPTION
Fix #56 

Also done a bit of tidy up on the JenkinsFile

- [x] added `PYTHONUNBUFFERED` to turn off stdout buffering so that I can see the next output line immediately in the Jenkins console view
- [x] removed host_key check and connection since that is covered by the `ansible.cfg`
- [x] removed the deprecated `accelerate_*`