### PR TITLE
Multiline shell module for tito doesn't work, reverting

### DIFF
--- a/playbooks/openshift/roles/cbs/tasks/cbs_build_srpms.yml
+++ b/playbooks/openshift/roles/cbs/tasks/cbs_build_srpms.yml
@@ -1,11 +1,7 @@
 ---
 
 - name: "Build srpm with tito for {{ project }}"
-  shell: >
-      tito build
-           --test --srpm
-           --rpmbuild-options="--define 'dist .el7'"
-           --output={{ openshift_repo_path }} | grep 'src.rpm' | awk '{print $NF}'
+  shell: tito build --test --srpm --rpmbuild-options="--define 'dist .el7'" --output={{ openshift_repo_path }} | grep 'src.rpm' | awk '{print $NF}'
   args:
     chdir: "{{ openshift_repo_path }}"
   register: tito_output_srpm


### PR DESCRIPTION
The error caused is 

`"cmd": "tito build\n --test --srpm\n --rpmbuild-options=\"--define 'dist .el7'\"\n --output=/root/origin | grep 'src.rpm' | awk '{print $NF}'"`

```
"stderr": "ERROR: Need an artifact type to build.  Use --rpm, --srpm, or --tgz\n/bin/sh: line 1: --test: command not found\n/bin/sh: line 2: --rpmbuild-options=--define 'dist .el7': command not found\n/bin/sh: line 3: --output=/root/origin: No such file or directory"
```