### PR TITLE
Overwrite CBS arch when BE is enabled to build only for x86_64.

### DIFF
--- a/playbooks/openshift/roles/cbs/defaults/main.yml
+++ b/playbooks/openshift/roles/cbs/defaults/main.yml
@@ -6,8 +6,5 @@ project: origin
 # Path to repo for {{ project }}
 openshift_repo_path: /root/{{ project }}
 
-# cbs target
-cbs_target: paas7-openshift-future-el7
-
 # scratch
 scratch: false

--- a/playbooks/openshift/roles/cbs/tasks/cbs_build_srpms.yml
+++ b/playbooks/openshift/roles/cbs/tasks/cbs_build_srpms.yml
@@ -10,11 +10,6 @@
   set_fact:
     srpm: "{{ tito_output_srpm.stdout }}"
 
-- name: "Set cbs_target to paas7-openshift-future-el7 for bleeding_edge"
-  set_fact:
-    cbs_target: paas7-openshift-future-el7
-  when: bleeding_edge | bool == true
-
 - name: "Scratch setting ON"
   set_fact:
     scratch_setting: --scratch
@@ -30,6 +25,14 @@
   args:
     chdir: "{{ openshift_repo_path }}"
   register: cbs_results
+  when: bleeding_edge | bool == false
+
+- name: "Cbs build target for {{ project }} from srpm - only x86_64 arch when BE"
+  command: cbs build --wait {{ scratch_setting }} --arch-override=x86_64 {{ cbs_target }} {{ srpm }}
+  args:
+    chdir: "{{ openshift_repo_path }}"
+  register: cbs_results
+  when: bleeding_edge | bool == true
 
 - debug:
     msg: "{{ cbs_results.stdout }}"


### PR DESCRIPTION
w/o this PR when BE flag is enabled, CBS will use the target arch and currently `paas7-openshift-future-el7` has both - see below

```
cbs taginfo paas7-openshift-future-el7-build
Tag: paas7-openshift-future-el7-build [793]
Arches: x86_64 aarch64
Groups: build, srpm-build
Tag options:
This tag is a buildroot for one or more targets
Current repo: repo#128257: 2018-06-17 03:16:03.430997
Targets that build from this tag:
  paas7-openshift-future-el7
External repos:
    2 centos7-cr (http://mirror.centos.org/centos/7/cr/$arch/)
    4 centos7-extras (http://mirror.centos.org/centos/7/extras/$arch/)
    5 centos7-updates (http://mirror.centos.org/centos/7/updates/$arch/)
   10 centos7-os (http://mirror.centos.org/centos/7/os/$arch/)
Inheritance:
  5    .... buildsys7 [6]
  10   .... paas7-openshift-future-candidate [790]
  15   .... paas7-openshift-common-candidate [705]
  20   .... paas7-common-candidate [702]
```

Checking the history with @tdawson it was done to allow testing for multi-arch.

When the multi-arch work will restart, i'll remove it, for now the focus is to get the BE jobs working again