### PR TITLE
EPEL 7 key

### DIFF
--- a/playbooks/openshift/roles/common/tasks/enable_epel.yml
+++ b/playbooks/openshift/roles/common/tasks/enable_epel.yml
@@ -3,7 +3,7 @@
 - name: "Get epel RPM signing key"
   rpm_key:
     state: present
-    key: https://getfedora.org/static/352C64E5.txt
+    key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 
 - name: "Enable epel repo"
   template:


### PR DESCRIPTION
pull the EPEL key from the fedora master download server as the website
redesign removed the existing URL

Signed-off-by: Dennis Gilmore <dennis@ausil.us>